### PR TITLE
feat: ✨ ブランチ名確認機能の追加とプロンプトの改善

### DIFF
--- a/src/bb/commands/branch_name.py
+++ b/src/bb/commands/branch_name.py
@@ -19,3 +19,7 @@ def branch_name(ctx: Context, description: str):
 
     branch_name = client.chat(SYSTEM_PROMPT, description)
     click.echo(branch_name)
+
+    if not click.confirm("\nConfirm the result?"):
+        client.clear_history()
+        ctx.invoke(branch_name, description=description)

--- a/src/bb/commands/pull_request.py
+++ b/src/bb/commands/pull_request.py
@@ -19,9 +19,11 @@ SYSTEM_PROMPT_BRANCH_NAME = (
     "Keep it short and readable. Ensure the branch name reflects the main changes or purpose indicated by the diff."
 )
 
+
 SYSTEM_PROMPT_PR_NAME = (
-    "You are an AI assistant. Based on the provided diff, generate a concise pull request name with a relevant prefix such as 'feat', 'fix', 'refactor', or other common prefixes. "
+    "You are an AI assistant. Based on the provided diff, generate a concise pull request name following the GitMoji specification with a relevant prefix such as 'feat', 'fix', 'refactor', or other common prefixes. "
     "Output should be in Japanese. "
+    "The format should be {prefix}:{emoji} {title}. "
     "Only output the pull request title and nothing else. "
     "Exclude any explanations, justifications, or conclusions."
 )


### PR DESCRIPTION
- `branch_name` 関数に結果確認のための確認プロンプトを追加
- 確認がキャンセルされた場合、履歴をクリアし再度 `branch_name` を呼び出す処理を追加
- プルリクエストのシステムプロンプトをGitMoji仕様に変更
- プルリクエスト名のフォーマットに関する説明を追加